### PR TITLE
fix(ci): GitHub Actions security hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: stable
+          # Don't restore the Go module/build cache in the signed-release flow:
+          # the Go build cache is trusted by input-hash (not go.sum-verified), so
+          # a cache poisoned by a less-trusted run could contaminate the release.
+          cache: false
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on your needs.
       - uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,13 @@ on:
     tags:
       - '*'
 
-permissions:
-  contents: write
-  # packages: write
-  # issues: write
+permissions: {}
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # goreleaser creates the GitHub release and uploads assets
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - run: git fetch --force --tags
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,13 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
Automated GitHub Actions security hardening (zizmor + actionlint + shellcheck,
plus manual review). Workflow-config only — no application code is touched.

## Changes

- **Scope down checkout credentials** — `persist-credentials: false` on the
  release checkout. The token is passed explicitly to goreleaser via `env` and
  the only downstream git op is a read-only `git fetch`, so the checkout token
  needn't be left in `.git/config`.

- **Scope `contents: write` to the goreleaser job** — the workflow-level
  `contents: write` becomes `permissions: {}` at the top, with `contents: write`
  granted only on the job that creates the release, plus a comment explaining
  why.

- **Add a zizmor config** — a `.github/zizmor.yml` disabling a few cosmetic
  pedantic rules (`anonymous-definition`, `undocumented-permissions`,
  `concurrency-limits`).

- **Disable the Go cache in the signed-release flow** — `cache: false` on
  `release.yml`'s `actions/setup-go`. The Go build cache stores compiled objects
  keyed by input hash and is reused on a cache hit without being re-verified
  against source (`go.sum` covers module *downloads*, not the build cache), so a
  cache poisoned by a less-trusted run could be restored into the tag-triggered
  signed-release build. Disabling it makes the release compile from clean,
  checksum-verified module downloads.

Refs: PSEC-923